### PR TITLE
[Feat] Mean baseline

### DIFF
--- a/rl4co/models/rl/reinforce/baselines.py
+++ b/rl4co/models/rl/reinforce/baselines.py
@@ -79,6 +79,12 @@ class ExponentialBaseline(REINFORCEBaseline):
         return self.v, 0  # No loss
 
 
+class MeanBaseline(REINFORCEBaseline):
+    """Mean baseline: return mean of reward as baseline"""
+    def __new__(cls, **kw):
+        return ExponentialBaseline(beta=0.0, **kw)
+
+
 class WarmupBaseline(REINFORCEBaseline):
     """Warmup baseline: return convex combination of baseline and exponential baseline
 
@@ -269,6 +275,7 @@ REINFORCE_BASELINES_REGISTRY = {
     "shared": SharedBaseline,
     "exponential": ExponentialBaseline,
     "critic": CriticBaseline,
+    "mean": MeanBaseline,
     "rollout_only": RolloutBaseline,
     "warmup": WarmupBaseline,
 }

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -6,7 +6,7 @@ from rl4co.utils import RL4COTrainer
 
 
 # Test out simple training loop and test with multiple baselines
-@pytest.mark.parametrize("baseline", ["rollout", "exponential", "critic", "no"])
+@pytest.mark.parametrize("baseline", ["rollout", "exponential", "critic", "mean", "no"])
 def test_reinforce(baseline):
     env = TSPEnv(num_loc=20)
 


### PR DESCRIPTION
## Description

Add simple mean baseline.
Mean baseline is just calculated as the average of the rewards in a batch.

## Motivation and Context

To add a simple baseline for model debugging.
`close #92`

- [x] I have raised an issue to propose this change ([here](https://github.com/kaist-silab/rl4co/issues/92))

## Types of changes

- [x] New feature (non-breaking change which adds core functionality)

## Checklist

- [] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [] I have updated the documentation accordingly.